### PR TITLE
Fix MAAPE formula in documentation

### DIFF
--- a/docs/source/pages/regression/MAAPE.rst
+++ b/docs/source/pages/regression/MAAPE.rst
@@ -18,7 +18,7 @@ MAAPE - Mean Arctangent Absolute Percentage Error
 
 .. math::
 
-	MAAPE = \frac{100}{n} \sum_{i=1}^{n} \left|\frac{A_i - F_i}{A_i}\right| \arctan\left(\frac{A_i - F_i}{A_i}\right)
+	MAAPE = \frac{100}{n} \sum_{i=1}^{n} \arctan\left(\left|\frac{A_i - F_i}{A_i}\right|\right)
 
 where A_i is the i-th actual value, F_i is the i-th forecasted value, and n is the number of observations.
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description
The Formula of the MAAPE as it currently is on the website has an error, specifically having the absolute value before the arctan and thereby summing the product of absolut error fraction and the arctan, instead of the arctan of the error fraction. Therefore, the changes are

Correction of 

\left|\frac{A_i - F_i}{A_i}\right| \arctan(\frac{A_i - F_i}{A_i})

to 

\arctan(\left|\frac{A_i - F_i}{A_i}\right|)

according to the formula
## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->